### PR TITLE
[WIP] StringSource#originalPositionFromPosition returns an incorrect position

### DIFF
--- a/test/StringSource-test.js
+++ b/test/StringSource-test.js
@@ -234,13 +234,16 @@ describe("StringSource", function() {
             let source = new StringSource(AST);
             let result = source.toString();
             assert.equal(result, "This is Example！？");
+            // The second whitespace
             assert.deepEqual(source.originalPositionFromPosition({
                 line: 1,
                 column: 8
             }), {
                 line: 1,
-                column: 9
+                column: 8
             });
+            // Example
+            //       ^
             assert.deepEqual(source.originalPositionFromPosition({
                 line: 1,
                 column: 15
@@ -255,15 +258,16 @@ describe("StringSource", function() {
             let source = new StringSource(AST);
             let result = source.toString();
             assert.equal(result, "First\nalt text");
-            // 4
             var lines = result.split("\n");
             var indexOf = lines[1].indexOf("text");
+            // text
+            // ^
             assert.deepEqual(source.originalPositionFromPosition({
-                line: lines.length,
-                column: indexOf
+                line: 2,
+                column: indexOf + 1
             }), {
                 line: 2,
-                column: 27
+                column: 28
             });
         });
         it("should return null when not found position for index", function() {
@@ -299,23 +303,25 @@ describe("StringSource", function() {
             let sentences = sentenceSplitter(result).filter(node => node.type === "Sentence");
             assert.equal(sentences.length, 3);
             let lastSentence = sentences[sentences.length - 1];
-            // Find "text" in a Sentence
+            // Find "text" in the third generated sentence
             let indexOf = lastSentence.value.indexOf("Text");
             assert.equal(indexOf, 4);
             // position in a sentence
+            // NOTE: textlint's column starts with 1
+            // while sentence-splitter's column starts with 0
             let matchWordPosition = {
                 line: lastSentence.loc.start.line,
-                column: lastSentence.loc.start.column + indexOf
+                column: lastSentence.loc.start.column + indexOf + 1
             };
             assert.deepEqual(matchWordPosition, {
                 line: 3,
-                column: 4
+                column: 5
             });
             // position in original text
             let originalMatchWordPosition = source.originalPositionFromPosition(matchWordPosition);
             assert.deepEqual(originalMatchWordPosition, {
                 line: 3,
-                column: 6
+                column: 7
             });
         });
     });


### PR DESCRIPTION
While `column` is the 1-based index according to [the textlint's documentation](https://github.com/textlint/textlint#use-as-node-modules), I've noticed that some tests regarding `originalPositionFromPosition` specified `index` (0-based index) as `column` (1-based index).

This PR fixes such tests, but currently one test fails with these changes, so I guess `originalPositionFromPosition` returns a wrong column value in some edge cases.

```
  1) StringSource #originalPositionFromPosition Str + Link:

        # test/StringSource-test.js:238

  assert.deepEqual(source.originalPositionFromPosition({ line: 1, column: 8 }), { line: 1, column: 8 })
                   |      |                            |                        |
                   |      Position{line:1,column:9}    Object{line:1,column:8}  Object{line:1,column:8}
                   StringSource{rootNode:#Object#,tokenMaps:#Array#,generatedString:"This is Example！？",originalSource:#StructuredSource#,generatedSource:#StructuredSource#}

      + expected - actual

       {
      -  "column": 9
      +  "column": 8
         "line": 1
       }

  AssertionError: Position { line: 1, column: 9 } deepEqual { line: 1, column: 8 }
      at Decorator._callFunc (node_modules/empower-core/lib/decorator.js:110:20)
      at Decorator.concreteAssert (node_modules/empower-core/lib/decorator.js:103:17)
      at Function.decoratedAssert [as deepEqual] (node_modules/empower-core/lib/decorate.js:49:30)
      at Context.<anonymous> (StringSource-test.js:238:20)
```

I'm sorry I'm yet to narrow the cause of this mismatch.

Do you have any thoughts or suggestions?