### PR TITLE
 fix(src): support Html node 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "dependencies": {
     "@textlint/ast-node-types": "^4.2.4",
     "@types/structured-source": "^3.0.0",
-    "structured-source": "^3.0.2"
+    "rehype-parse": "^6.0.1",
+    "structured-source": "^3.0.2",
+    "unified": "^8.4.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build": "cross-env NODE_ENV=production tsc -p .",
     "prepublish": "npm run --if-present build",
     "test": "mocha \"test/**/*.{js,ts}\"",
-    "watch": "tsc -p . --watch"
+    "watch": "tsc -p . --watch",
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\""
   },
   "dependencies": {
     "@textlint/ast-node-types": "^4.2.4",
@@ -38,12 +39,31 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.5",
     "cross-env": "^5.2.1",
+    "husky": "^3.0.5",
+    "lint-staged": "^9.2.5",
     "markdown-to-ast": "^4.0.0",
     "mocha": "^6.2.0",
+    "prettier": "^1.18.2",
     "sentence-splitter": "^2.0.0",
     "ts-node": "^8.4.1",
     "ts-node-test-register": "^8.0.1",
     "typescript": "^3.6.3"
   },
-  "email": "azuciao@gmail.com"
+  "email": "azuciao@gmail.com",
+  "prettier": {
+    "singleQuote": false,
+    "printWidth": 120,
+    "tabWidth": 4
+  },
+  "husky": {
+    "hooks": {
+      "precommit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,css}": [
+      "prettier --write",
+      "git add"
+    ]
+  }
 }

--- a/src/StringSource.ts
+++ b/src/StringSource.ts
@@ -2,6 +2,16 @@
 "use strict";
 import { TxtNode, TxtParentNode } from "@textlint/ast-node-types";
 import StructuredSource, { SourcePosition } from "structured-source";
+
+const unified = require('unified');
+const parse = require('rehype-parse');
+
+const html2hast = (html: string): TxtParentNode => {
+    return unified()
+        .use(parse, {fragment: true})
+        .parse(html)
+};
+
 /* StringSourceIR example
  Example: **Str**
  {
@@ -284,14 +294,16 @@ export default class StringSource {
      * @param {Node} [parent] - Parent Node of the `node`.
      */
     private _stringify(node: TxtNode | TxtParentNode, parent?: TxtParentNode): void | StringSourceIR {
-        let value = this._valueOf(node, parent);
+        const isHTML = node.type === "Html";
+        const currentNode = isHTML ? html2hast(node.value) : node;
+        const value = this._valueOf(currentNode, parent);
         if (value) {
             return value;
         }
         if (!isParentNode(node)) {
             return;
         }
-        node.children.forEach((childNode: TxtNode) => {
+        currentNode.children.forEach((childNode: TxtNode) => {
             if (!isParentNode(node)) {
                 return;
             }

--- a/src/StringSource.ts
+++ b/src/StringSource.ts
@@ -3,13 +3,13 @@
 import { TxtNode, TxtParentNode } from "@textlint/ast-node-types";
 import StructuredSource, { SourcePosition } from "structured-source";
 
-const unified = require('unified');
-const parse = require('rehype-parse');
+const unified = require("unified");
+const parse = require("rehype-parse");
 
 const html2hast = (html: string): TxtParentNode => {
     return unified()
-        .use(parse, {fragment: true})
-        .parse(html)
+        .use(parse, { fragment: true })
+        .parse(html);
 };
 
 /* StringSourceIR example
@@ -29,11 +29,11 @@ const html2hast = (html: string): TxtParentNode => {
  */
 
 type StringSourceIR = {
-    original: readonly [number, number],
-    intermediate: readonly [number, number],
+    original: readonly [number, number];
+    intermediate: readonly [number, number];
     generatedValue: string;
     generated?: [number, number];
-}
+};
 export default class StringSource {
     private rootNode: TxtParentNode;
     private generatedString: string;
@@ -182,7 +182,6 @@ export default class StringSource {
         return this.originalSource.indexToPosition(originalIndex);
     }
 
-
     isParagraphNode(node: TxtNode): boolean {
         return node.type === "Paragraph";
     }
@@ -215,17 +214,13 @@ export default class StringSource {
 
     private _nodeRangeAsRelative(node: TxtNode): [number, number] {
         // relative from root
-        return [
-            node.range[0] - this.rootNode.range[0],
-            node.range[1] - this.rootNode.range[0]
-        ]
+        return [node.range[0] - this.rootNode.range[0], node.range[1] - this.rootNode.range[0]];
     }
 
     private _valueOf(node: TxtNode, parent?: TxtParentNode): StringSourceIR | undefined {
         if (!node) {
             return;
         }
-
 
         // [padding][value][padding]
         // =>
@@ -257,16 +252,12 @@ export default class StringSource {
         let paddingRight = rawValue.length - (paddingLeft + value.length);
         // original range should be relative value from rootNode
         let originalRange = this._nodeRangeAsRelative(container);
-        let intermediateRange = [
-            originalRange[0] + paddingLeft,
-            originalRange[1] - paddingRight
-        ] as const;
+        let intermediateRange = [originalRange[0] + paddingLeft, originalRange[1] - paddingRight] as const;
         return {
             original: originalRange,
             intermediate: intermediateRange,
             generatedValue: value
         };
-
     }
 
     private _addTokenMap(tokenMap: StringSourceIR) {
@@ -315,6 +306,6 @@ export default class StringSource {
     }
 }
 
-const isParentNode = (node: TxtNode | TxtParentNode): node is  TxtParentNode => {
+const isParentNode = (node: TxtNode | TxtParentNode): node is TxtParentNode => {
     return "children" in node;
 };

--- a/test/StringSource-test.js
+++ b/test/StringSource-test.js
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-import assert from "assert"
+import assert from "assert";
 import { parse } from "markdown-to-ast";
 import StringSource from "../src/StringSource";
 import { split as sentenceSplitter } from "sentence-splitter";
@@ -202,38 +202,22 @@ describe("StringSource", function() {
             assert.strictEqual(indexOfOriginal, 9);
             assert.strictEqual(source.tokenMaps.length, 2);
             assert.deepStrictEqual(source.tokenMaps[0], {
-                "generated": [
-                    0,
-                    6,
-                ],
-                "generatedValue": "It is ",
-                "intermediate": [
-                    0,
-                    6,
-                ],
-                "original": [
-                    0,
-                    6,
-                ]
+                generated: [0, 6],
+                generatedValue: "It is ",
+                intermediate: [0, 6],
+                original: [0, 6]
             });
             assert.deepStrictEqual(source.tokenMaps[1], {
-                "generated": [
-                    6,
-                    10,
-                ],
-                "generatedValue": "TEST",
-                "intermediate": [
-                    9,
-                    13,
-                ],
-                "original": [
-                    9,
-                    13,
-                ]
-            })
+                generated: [6, 10],
+                generatedValue: "TEST",
+                intermediate: [9, 13],
+                original: [9, 13]
+            });
         });
-        it("complex html tag", function () {
-            const AST = parse(`<a href="http://example.com" title="example"><img src="http://example.com" />TEST1</a> **BOLD** <b>TEST2</b>`);
+        it("complex html tag", function() {
+            const AST = parse(
+                `<a href="http://example.com" title="example"><img src="http://example.com" />TEST1</a> **BOLD** <b>TEST2</b>`
+            );
             const source = new StringSource(AST);
             const result = source.toString();
             assert.strictEqual(result, "TEST1 BOLD TEST2");
@@ -243,7 +227,6 @@ describe("StringSource", function() {
             const index2Generated = result.indexOf("TEST2");
             const index2Original = source.originalIndexFromIndex(index2Generated);
             assert.strictEqual(index2Original, 99);
-
         });
         it("confusing pattern", function() {
             let AST = parse("![!](http://example.com)");
@@ -347,20 +330,26 @@ describe("StringSource", function() {
             let source = new StringSource(AST);
             let result = source.toString();
             assert.equal(result, "This is Example！？");
-            assert.deepEqual(source.originalPositionFromPosition({
-                line: 1,
-                column: 8
-            }), {
-                line: 1,
-                column: 9
-            });
-            assert.deepEqual(source.originalPositionFromPosition({
-                line: 1,
-                column: 15
-            }), {
-                line: 1,
-                column: 16
-            });
+            assert.deepEqual(
+                source.originalPositionFromPosition({
+                    line: 1,
+                    column: 8
+                }),
+                {
+                    line: 1,
+                    column: 9
+                }
+            );
+            assert.deepEqual(
+                source.originalPositionFromPosition({
+                    line: 1,
+                    column: 15
+                }),
+                {
+                    line: 1,
+                    column: 16
+                }
+            );
         });
         it("should return the original position from a position in a generated sentence", function() {
             var originalText = "First\n![alt](http://example.png) text";
@@ -371,13 +360,16 @@ describe("StringSource", function() {
             // 4
             var lines = result.split("\n");
             var indexOf = lines[1].indexOf("text");
-            assert.deepEqual(source.originalPositionFromPosition({
-                line: lines.length,
-                column: indexOf
-            }), {
-                line: 2,
-                column: 27
-            });
+            assert.deepEqual(
+                source.originalPositionFromPosition({
+                    line: lines.length,
+                    column: indexOf
+                }),
+                {
+                    line: 2,
+                    column: 27
+                }
+            );
         });
         it("should return null when the specified position is invalid", function() {
             var originalText = "![alt](http://example.png) text";
@@ -385,10 +377,13 @@ describe("StringSource", function() {
             let source = new StringSource(AST);
             let result = source.toString();
             assert.equal(result, "alt text");
-            assert.equal(source.originalPositionFromPosition({
-                line: -1,
-                column: -1
-            }), null);
+            assert.equal(
+                source.originalPositionFromPosition({
+                    line: -1,
+                    column: -1
+                }),
+                null
+            );
         });
         it("should throw error when the specified position is not an object", function() {
             var originalText = "![alt](http://example.png) text";
@@ -401,9 +396,7 @@ describe("StringSource", function() {
             });
         });
         it("with sentenceSplitter", function() {
-            var originalText = "`1`st.\n" +
-                "``2`nd.`\n" +
-                "`3`rd Text.";
+            var originalText = "`1`st.\n" + "``2`nd.`\n" + "`3`rd Text.";
             let AST = parse(originalText);
             // Node -> Plain Text
             let source = new StringSource(AST);
@@ -432,5 +425,4 @@ describe("StringSource", function() {
             });
         });
     });
-
 });

--- a/test/StringSource-test.js
+++ b/test/StringSource-test.js
@@ -192,6 +192,59 @@ describe("StringSource", function() {
                 generatedValue: " text"
             });
         });
+        it("inline html tag", function() {
+            const AST = parse("It is <p>TEST</p>");
+            const source = new StringSource(AST);
+            const result = source.toString();
+            assert.strictEqual(result, "It is TEST");
+            const indexOfGenerated = result.indexOf("TEST");
+            const indexOfOriginal = source.originalIndexFromIndex(indexOfGenerated);
+            assert.strictEqual(indexOfOriginal, 9);
+            assert.strictEqual(source.tokenMaps.length, 2);
+            assert.deepStrictEqual(source.tokenMaps[0], {
+                "generated": [
+                    0,
+                    6,
+                ],
+                "generatedValue": "It is ",
+                "intermediate": [
+                    0,
+                    6,
+                ],
+                "original": [
+                    0,
+                    6,
+                ]
+            });
+            assert.deepStrictEqual(source.tokenMaps[1], {
+                "generated": [
+                    6,
+                    10,
+                ],
+                "generatedValue": "TEST",
+                "intermediate": [
+                    9,
+                    13,
+                ],
+                "original": [
+                    9,
+                    13,
+                ]
+            })
+        });
+        it("complex html tag", function () {
+            const AST = parse(`<a href="http://example.com" title="example"><img src="http://example.com" />TEST1</a> **BOLD** <b>TEST2</b>`);
+            const source = new StringSource(AST);
+            const result = source.toString();
+            assert.strictEqual(result, "TEST1 BOLD TEST2");
+            const index1Generated = result.indexOf("TEST1");
+            const index1Original = source.originalIndexFromIndex(index1Generated);
+            assert.strictEqual(index1Original, 77);
+            const index2Generated = result.indexOf("TEST2");
+            const index2Original = source.originalIndexFromIndex(index2Generated);
+            assert.strictEqual(index2Original, 99);
+
+        });
         it("confusing pattern", function() {
             let AST = parse("![!](http://example.com)");
             let source = new StringSource(AST);

--- a/test/StringSource-txt-test.js
+++ b/test/StringSource-txt-test.js
@@ -1,62 +1,53 @@
 // LICENSE : MIT
 "use strict";
-import assert from "assert"
+import assert from "assert";
 import StringSource from "../src/StringSource";
 describe("StringSource AST", function() {
     describe("#toString", function() {
         it("should concat string", function() {
             const AST = {
-                "type": "Document",
-                "raw": "Str",
-                "range": [
-                    0,
-                    3
-                ],
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 0
+                type: "Document",
+                raw: "Str",
+                range: [0, 3],
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
                     },
-                    "end": {
-                        "line": 1,
-                        "column": 3
+                    end: {
+                        line: 1,
+                        column: 3
                     }
                 },
-                "children": [
+                children: [
                     {
-                        "type": "Paragraph",
-                        "raw": "Str",
-                        "range": [
-                            0,
-                            3
-                        ],
-                        "loc": {
-                            "start": {
-                                "line": 1,
-                                "column": 0
+                        type: "Paragraph",
+                        raw: "Str",
+                        range: [0, 3],
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 0
                             },
-                            "end": {
-                                "line": 1,
-                                "column": 3
+                            end: {
+                                line: 1,
+                                column: 3
                             }
                         },
-                        "children": [
+                        children: [
                             {
-                                "type": "Str",
-                                "raw": "Str",
-                                "value": "Str",
-                                "range": [
-                                    0,
-                                    3
-                                ],
-                                "loc": {
-                                    "start": {
-                                        "line": 1,
-                                        "column": 0
+                                type: "Str",
+                                raw: "Str",
+                                value: "Str",
+                                range: [0, 3],
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 0
                                     },
-                                    "end": {
-                                        "line": 1,
-                                        "column": 3
+                                    end: {
+                                        line: 1,
+                                        column: 3
                                     }
                                 }
                             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,11 @@
   resolved "https://registry.yarnpkg.com/@types/structured-source/-/structured-source-3.0.0.tgz#e95d76037d400c1957f3b709f023b308e92f3829"
   integrity sha512-8u+Wo5+GEXe4jZyQ8TplLp+1A7g32ZcVoE7VZu8VcxnlaEm5I/+T579R7q3qKN76jmK0lRshpo4hl4bj/kEPKA==
 
+"@types/unist@^2.0.0", "@types/unist@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
+  integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
 ansi-colors@3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
@@ -133,6 +138,11 @@ ccount@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.1.tgz#665687945168c218ec77ff61a4155ae00227a96c"
 
+ccount@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
+  integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
+
 chalk@^2.0.0, chalk@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -186,6 +196,11 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz#419cd7fb3258b1ed838dc0953167a25e152f5b59"
+  integrity sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -425,6 +440,32 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hast-util-from-parse5@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-5.0.1.tgz#7da8841d707dcf7be73715f7f3b14e021c4e469a"
+  integrity sha512-UfPzdl6fbxGAxqGYNThRUhRlDYY7sXu6XU9nQeX4fFZtV+IHbyEJtd+DUuwOqNV4z3K05E/1rIkoVr/JHmeWWA==
+  dependencies:
+    ccount "^1.0.3"
+    hastscript "^5.0.0"
+    property-information "^5.0.0"
+    web-namespaces "^1.1.2"
+    xtend "^4.0.1"
+
+hast-util-parse-selector@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz#66aabccb252c47d94975f50a281446955160380b"
+  integrity sha512-jIMtnzrLTjzqgVEQqPEmwEZV+ea4zHRFTP8Z2Utw0I5HuBOXHzUPPQWr6ouJdJqDKLbFU/OEiYwZ79LalZkmmw==
+
+hastscript@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-5.1.0.tgz#a19b3cca6a26a2bcd0f1b1eac574af9427c1c7df"
+  integrity sha512-7mOQX5VfVs/gmrOGlN8/EDfp1GqV6P3gTNVt+KnX4gbYhpASTM8bklFdFQCbFRAadURXAmw0R1QQdBdqp7jswQ==
+  dependencies:
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.2.0"
+    property-information "^5.0.1"
+    space-separated-tokens "^1.0.0"
+
 he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -475,7 +516,7 @@ is-buffer@^1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
-is-buffer@~2.0.3:
+is-buffer@^2.0.0, is-buffer@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
@@ -512,6 +553,11 @@ is-hexadecimal@^1.0.0:
 is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
+is-plain-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.0.0.tgz#7fd1a7f1b69e160cde9181d2313f445c68aa2679"
+  integrity sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==
 
 is-regex@^1.0.4:
   version "1.0.4"
@@ -850,6 +896,11 @@ parse-json@^5.0.0:
     json-parse-better-errors "^1.0.1"
     lines-and-columns "^1.1.6"
 
+parse5@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -872,6 +923,13 @@ path-parse@^1.0.6:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+property-information@^5.0.0, property-information@^5.0.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.2.2.tgz#20555eafd2296278a682e5a51d5123e7878ecc30"
+  integrity sha512-N2moasZmjn2mjVGIWpaqz5qnz6QyeQSGgGvMtl81gA9cPTWa6wpesRSe/quNnOjUHpvSH1oZx0pdz0EEckLFnA==
+  dependencies:
+    xtend "^4.0.1"
 
 pump@^3.0.0:
   version "3.0.0"
@@ -902,6 +960,15 @@ readable-stream@^2.2.2:
     process-nextick-args "~1.0.6"
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
+
+rehype-parse@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-6.0.1.tgz#a5401d7f4144d5e17cbb69be11f05a2a7ba87e27"
+  integrity sha512-FrGSbOzcGxIvWty1qHjKTvHT4WBTt7C6JLs65EkvFPa7ZKraSmsoDDj6al1eBxaXS1t/kiGdPYazUe58Mgflgw==
+  dependencies:
+    hast-util-from-parse5 "^5.0.0"
+    parse5 "^5.0.0"
+    xtend "^4.0.1"
 
 remark-parse@^3.0.0:
   version "3.0.1"
@@ -1029,6 +1096,11 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+space-separated-tokens@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz#27910835ae00d0adfcdbd0ad7e611fb9544351fa"
+  integrity sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -1239,6 +1311,17 @@ unified@^6.0.0:
     x-is-function "^1.0.4"
     x-is-string "^0.1.0"
 
+unified@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-8.4.0.tgz#5bb8a05c2a0b9dcc56152312ad8e4578a0d90af7"
+  integrity sha512-hQqeCrzqqS3vk8WbvbjYgaxe9WqmZF32Y3lz/kY5A8/5RdJbxoa4yOIAYpSEvqii9n2MTI2OL1+ByoVJYLhlUg==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
+
 unist-util-modify-children@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.0.tgz#559203ae85d7a76283277be1abfbaf595a177ead"
@@ -1256,6 +1339,13 @@ unist-util-stringify-position@^1.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.0.tgz#e8ba9d6b6af891b5f8336b3a31c63a9dc85c2af0"
   dependencies:
     has "^1.0.1"
+
+unist-util-stringify-position@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz#de2a2bc8d3febfa606652673a91455b6a36fb9f3"
+  integrity sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==
+  dependencies:
+    "@types/unist" "^2.0.2"
 
 unist-util-visit@^1.1.0:
   version "1.1.1"
@@ -1277,6 +1367,14 @@ vfile-location@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.1.tgz#0bf8816f732b0f8bd902a56fda4c62c8e935dc52"
 
+vfile-message@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.1.tgz#951881861c22fc1eb39f873c0b93e336a64e8f6d"
+  integrity sha512-KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==
+  dependencies:
+    "@types/unist" "^2.0.2"
+    unist-util-stringify-position "^2.0.0"
+
 vfile@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.0.1.tgz#bd48e68e8a2322dff0d162a37f45e70d9bb30466"
@@ -1286,6 +1384,22 @@ vfile@^2.0.0:
     replace-ext "1.0.0"
     unist-util-stringify-position "^1.0.0"
     x-is-string "^0.1.0"
+
+vfile@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.0.1.tgz#fc3d43a1c71916034216bf65926d5ee3c64ed60c"
+  integrity sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^2.0.0"
+    vfile-message "^2.0.0"
+
+web-namespaces@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.3.tgz#9bbf5c99ff0908d2da031f1d732492a96571a83f"
+  integrity sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
fix to handle html node
```html
<a href="http://example.com" title="example"><img src="http://example.com" />TEST1</a> **BOLD** <b>TEST2</b>`
```

https://github.com/textlint-rule/textlint-rule-sentence-length/issues/13